### PR TITLE
Cleanup and fix emitter structure

### DIFF
--- a/python/race_core/common.py
+++ b/python/race_core/common.py
@@ -12,6 +12,9 @@ class Emitter:
         for l in self.listeners:
             l(*args, **kwargs)
 
+    def __call__(self, *args, **kwargs):
+        self.emit(*args, **kwargs)
+
 
 def mklog(prefix, level):
     def logany(*args, **kwargs):

--- a/python/race_core/core.py
+++ b/python/race_core/core.py
@@ -19,13 +19,13 @@ logging.basicConfig(
 
 
 class RaceCore:
-    def __init__(self, device, server, user, password):
+    def __init__(self, tracker, server, user, password):
         self.mqtt_server = server
         self.mqtt_user = user
         self.mqtt_password = password
         self.client = None
 
-        self.tracker = LapRFRaceTracker(device)
+        self.tracker = tracker
         self.tracker.on_version.connect(logging.info)
         self.tracker.on_passing_packet.connect(self.on_pilot_passed)
 
@@ -82,7 +82,9 @@ class RaceCore:
 def main(device):
     logging.info("starting up")
 
-    rc = RaceCore(device, "localhost", "openrace", "PASSWORD")
+    rc = RaceCore(
+        LapRFRaceTracker(device),
+        "localhost", "openrace", "PASSWORD")
     rc.mqtt_connect()
     rc.run()
 

--- a/python/race_core/handlers/laprf.py
+++ b/python/race_core/handlers/laprf.py
@@ -437,13 +437,13 @@ class lapRFprotocol:
             #            logging.debug("[" + str((decoder_id, passing_number, transponder, rtc_time,
             #            passing_strength, passing_hits, passing_flags)) + "]")
 
-            self.passing_packet.emit(
-                decoder_id,
-                detection_number,
-                pilot_id,
-                rtc_time,
-                detection_peak_height,
-                detection_flags,
+            self.passing_packet(
+                decoder_id=           decoder_id,
+                detection_number=     detection_number,
+                pilot_id=             pilot_id,
+                rtc_time=             rtc_time,
+                detection_peak_height=detection_peak_height,
+                detection_flags=      detection_flags,
             )
 
         elif TOR == TOR_constants["RF_SETTINGS"]:

--- a/python/race_core/handlers/racetracker.py
+++ b/python/race_core/handlers/racetracker.py
@@ -63,8 +63,9 @@ class LapRFRaceTracker(RaceTracker):
             lambda version, _: self.on_version.emit(".".join([str(x) for x in version]))
         )
         self.laprf.version_packet.connect(mklog('version_packet', 'debug'))
-        # self.laprf.passing_packet.connect(self.pilot_passed)
-        self.laprf.passing_packet.connect(mklog('passing_packet', 'debug'))
+
+        self.laprf.passing_packet.connect(self.pilot_passed)
+        #self.laprf.passing_packet.connect(mklog('passing_packet', 'debug'))
 
 
     def request_version(self):
@@ -80,15 +81,21 @@ class LapRFRaceTracker(RaceTracker):
         self.serial_dev.read_data(stop_if_no_data)
 
     # Emitting methods
-    def pilot_passed(self):
+    def pilot_passed(
+            self,
+            decoder_id,
+            detection_number,
+            pilot_id,
+            rtc_time,
+            detection_peak_height,
+            detection_flags):
         logging.debug("Passing packet:")
-        logging.debug("decoder_id:            " % decoder_id)
-        logging.debug("detection_number:      " % detection_number)
-        logging.debug("pilot_id:              " % pilot_id)
-        logging.debug("rtc_time:              " % rtc_time)
-        logging.debug("detection_peak_height: " % detection_peak_height)
-        logging.debug("detection_flags:       " % detection_flags)
-        pass
+        logging.debug("decoder_id:            %s" % decoder_id)
+        logging.debug("detection_number:      %s" % detection_number)
+        logging.debug("pilot_id:              %s" % pilot_id)
+        logging.debug("rtc_time:              %s" % rtc_time)
+        logging.debug("detection_peak_height: %s" % detection_peak_height)
+        logging.debug("detection_flags:       %s" % detection_flags)
 
     # laprf.request_save_settings
     # laprf.request_shutdown


### PR DESCRIPTION
* Emitters can now be called directly (not via .emit method), making
  chaining a bit easier.
* More generic initialisation of RaceCore
* fix logging of "pilot passed" message