### PR TITLE
make it possible to configure mqtt host for angular-ui service

### DIFF
--- a/python/angular-ui/Dockerfile
+++ b/python/angular-ui/Dockerfile
@@ -15,4 +15,6 @@ FROM nginx:1.15.8-alpine
 
 COPY --from=node /usr/src/app/dist/angular-ui /usr/share/nginx/html
 
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/conf.d/nginx.conf.template
+
+CMD envsubst '$$MQTT_WEBSOCKETS_HOST' < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'

--- a/python/angular-ui/nginx.conf
+++ b/python/angular-ui/nginx.conf
@@ -1,8 +1,0 @@
-server {
-  listen 80;
-  location / {
-    root /usr/share/nginx/html;
-    index index.html index.htm;
-    try_files $uri $uri/ /index.html =404;
-  }
-}

--- a/python/angular-ui/nginx.conf.template
+++ b/python/angular-ui/nginx.conf.template
@@ -1,0 +1,19 @@
+upstream mqtt-service {
+    server ${MQTT_WEBSOCKETS_HOST};
+}
+
+server {
+  listen 80;
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+  }
+
+  location /mqtt/ {
+          proxy_pass http://mqtt-service/mqtt/;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+      }
+}

--- a/python/angular-ui/src/app/open-race-common/open-race-common.module.ts
+++ b/python/angular-ui/src/app/open-race-common/open-race-common.module.ts
@@ -4,8 +4,8 @@ import { IMqttServiceOptions, MqttModule } from 'ngx-mqtt';
 
 export const MQTT_SERVICE_OPTIONS: IMqttServiceOptions = {
   hostname: 'localhost',
-  port: 9001,
-  path: '/mqtt',
+  port: 5001,
+  path: '/mqtt/',
   username: 'openrace',
   password: 'PASSWORD'
 };

--- a/python/docker-compose.yml
+++ b/python/docker-compose.yml
@@ -7,12 +7,12 @@ services:
     restart: always
     image: "eclipse-mosquitto"
     ports:
-     - "1883:1883"
-     - "9001:9001"
+      - "1883:1883"
+      - "9001:9001"
     volumes:
-     - "/srv/mqtt/config/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro"
-#     - "/srv/mqtt/log:/mosquitto/log:rw"
-     - "/srv/mqtt/data:/mosquitto/data:rw"
+      - "/srv/mqtt/config/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro"
+      - "/srv/mqtt/log:/mosquitto/log:rw"
+      - "/srv/mqtt/data:/mosquitto/data:rw"
 
   race_core:
     restart: always
@@ -49,35 +49,33 @@ services:
       - MQTT_PASS=${MQTT_PASS}
       - DEBUG=${DEBUG}
 
-#  webui:
-#    restart: always
-#    build:
-#      context: "webui/"
-#    depends_on:
-#      - "mqtt"
-#    links:
-#      - "mqtt"
-#    ports:
-#      - "80:5000"
-#    volumes:
-#     - "/srv/openrace/log:/app/log/:rw"
-#    environment:
-#      - MQTT_HOST=${MQTT_HOST}
-#      - MQTT_USER=${MQTT_USER}
-#      - MQTT_PASS=${MQTT_PASS}
-#      - FLASK_ENV=${FLASK_ENV}
-#
-#  angular-ui:
-#    restart: always
-#    build:
-#      context: "angular-ui/"
-#    depends_on:
-#        - "mqtt"
-#    links:
-#        - "mqtt"
-#    ports:
-#      - "80:5001"
-#    environment:
-#      - MQTT_HOST=${MQTT_HOST}
-#      - MQTT_USER=${MQTT_USER}
-#      - MQTT_PASS=${MQTT_PASS}
+  #  webui:
+  #    restart: always
+  #    build:
+  #      context: "webui/"
+  #    depends_on:
+  #      - "mqtt"
+  #    links:
+  #      - "mqtt"
+  #    ports:
+  #      - "80:5000"
+  #    volumes:
+  #     - "/srv/openrace/log:/app/log/:rw"
+  #    environment:
+  #      - MQTT_HOST=${MQTT_HOST}
+  #      - MQTT_USER=${MQTT_USER}
+  #      - MQTT_PASS=${MQTT_PASS}
+  #      - FLASK_ENV=${FLASK_ENV}
+  #
+  angular-ui:
+    restart: always
+    build:
+      context: "angular-ui/"
+    depends_on:
+        - "mqtt"
+    links:
+        - "mqtt"
+    ports:
+      - "5001:80"
+    environment:
+      - MQTT_WEBSOCKETS_HOST=mqtt:9001


### PR DESCRIPTION
- environment variable MQTT_WEBSOCKETS_HOST let you provide the server:port on which mosquitto websocket is listening
- currently the env var is set to mqtt:9001 and thus using the docker service resolution