### PR TITLE
Draggable led order

### DIFF
--- a/python/angular-ui/src/app/open-race-led-strips/edit-led-strip/edit-led-strip.component.html
+++ b/python/angular-ui/src/app/open-race-led-strips/edit-led-strip/edit-led-strip.component.html
@@ -8,9 +8,6 @@
                     value="{{stripCategory}}">{{stripCategory}}</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field>
-      <input matInput placeholder="Position" name="position" [(ngModel)]="ledStrip.order">
-    </mat-form-field>
     <button type="button" (click)="testFlashLedStrip()" mat-stroked-button color="accent">Test</button>
     <button type="submit" mat-flat-button color="primary">Save</button>
   </div>

--- a/python/angular-ui/src/app/open-race-led-strips/edit-led-strip/edit-led-strip.component.ts
+++ b/python/angular-ui/src/app/open-race-led-strips/edit-led-strip/edit-led-strip.component.ts
@@ -21,7 +21,7 @@ export class EditLedStripComponent implements OnInit {
   }
 
   updateLedStrip() {
-    this.ledStripService.updateLedStrips(this.ledStrip);
+    this.ledStripService.updateLedStripCategory(this.ledStrip);
   }
 
   testFlashLedStrip() {

--- a/python/angular-ui/src/app/open-race-led-strips/led-strips-list/led-strips-list.component.html
+++ b/python/angular-ui/src/app/open-race-led-strips/led-strips-list/led-strips-list.component.html
@@ -1,6 +1,12 @@
-<div fxLayout="column" fxLayoutGap="1em">
-  <mat-card *ngFor="let ledStrip of ledStrips" class="mat-elevation-z15">
-    <div class="mat-title">LED Strip {{ledStrip.id}}</div>
-    <app-edit-led-strip [ledStrip]="ledStrip"></app-edit-led-strip>
+<div fxLayout="column" fxLayoutGap="1em" cdkDropListGroup>
+  <mat-card fxLayout="column" fxLayoutGap="1em" cdkDropList>
+    <div class="mat-title">Obstacle</div>
+    <mat-card *ngFor="let ledStrip of ledStrips" class="mat-elevation-z15" cdkDrag>
+      <div class="mat-title">LED Strip {{ledStrip.id}}</div>
+      <app-edit-led-strip [ledStrip]="ledStrip"></app-edit-led-strip>
+    </mat-card>
+  </mat-card>
+  <mat-card cdkDropList>
+    <div class="mat-title">New Obstacle</div>
   </mat-card>
 </div>

--- a/python/angular-ui/src/app/open-race-led-strips/led-strips-list/led-strips-list.component.html
+++ b/python/angular-ui/src/app/open-race-led-strips/led-strips-list/led-strips-list.component.html
@@ -1,12 +1,6 @@
-<div fxLayout="column" fxLayoutGap="1em" cdkDropListGroup>
-  <mat-card fxLayout="column" fxLayoutGap="1em" cdkDropList>
-    <div class="mat-title">Obstacle</div>
+<div fxLayout="column" fxLayoutGap="1em" cdkDropList (cdkDropListDropped)="drop($event)">
     <mat-card *ngFor="let ledStrip of ledStrips" class="mat-elevation-z15" cdkDrag>
       <div class="mat-title">LED Strip {{ledStrip.id}}</div>
       <app-edit-led-strip [ledStrip]="ledStrip"></app-edit-led-strip>
     </mat-card>
-  </mat-card>
-  <mat-card cdkDropList>
-    <div class="mat-title">New Obstacle</div>
-  </mat-card>
 </div>

--- a/python/angular-ui/src/app/open-race-led-strips/led-strips-list/led-strips-list.component.ts
+++ b/python/angular-ui/src/app/open-race-led-strips/led-strips-list/led-strips-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { LedStrip } from '../led-strip';
 import { LedStripsService } from '../led-strips.service';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 
 @Component({
   selector: 'app-led-strips-list',
@@ -17,4 +18,11 @@ export class LedStripsListComponent implements OnInit {
   ngOnInit() {
   }
 
+  drop(event: CdkDragDrop<string[]>) {
+    moveItemInArray(this.ledStrips, event.previousIndex, event.currentIndex);
+    for (let i = 0; i < this.ledStrips.length; i++) {
+      this.ledStrips[i].order = i.toString();
+      this.ledStripsService.updateLedStripOrder(this.ledStrips[i]);
+    }
+  }
 }

--- a/python/angular-ui/src/app/open-race-led-strips/led-strips.service.ts
+++ b/python/angular-ui/src/app/open-race-led-strips/led-strips.service.ts
@@ -30,10 +30,15 @@ export class LedStripsService {
     }
   }
 
-  updateLedStrips(ledStrip: LedStrip) {
+  updateLedStripCategory(ledStrip: LedStrip) {
     const ledStripId = ledStrip.id;
 
     this.publishLedStripMessage(ledStripId, 'category', ledStrip.category);
+  }
+
+  updateLedStripOrder(ledStrip: LedStrip) {
+    const ledStripId = ledStrip.id;
+
     this.publishLedStripMessage(ledStripId, 'order', ledStrip.order);
   }
 
@@ -64,7 +69,7 @@ export class LedStripsService {
     LedStripsService.applyLedStripUpdate(property, this.safeGetLedStrip(ledStripId), value);
 
     console.log(Array.from(this.ledStripsStore.values()));
-    this._ledStrips.next(Array.from(this.ledStripsStore.values()).sort((a: LedStrip, b: LedStrip) => a.id >= b.id ? 1 : -1));
+    this._ledStrips.next(Array.from(this.ledStripsStore.values()).sort((a: LedStrip, b: LedStrip) => a.order >= b.order ? 1 : -1));
   }
 
   private safeGetLedStrip(ledStripId: string) {


### PR DESCRIPTION
- it is now possible to define a relative led strip order using drag and drop
- it is no longer possible to set the order using text